### PR TITLE
Keep `Scope::Container` reference in `$env` for streaming response

### DIFF
--- a/lib/Plack/Middleware/Scope/Container.pm
+++ b/lib/Plack/Middleware/Scope/Container.pm
@@ -10,10 +10,8 @@ our $VERSION = '0.02';
 sub call {
     my ( $self, $env) = @_;
     my $container = start_scope_container();
-    my $res = $self->app->($env);
-    return $self->response_cb($res, sub {
-        undef $container;
-    });
+    $env->{'scope.container'} = $container;
+    $self->app->($env);
 }
 
 1;

--- a/t/03_streaming.t
+++ b/t/03_streaming.t
@@ -1,0 +1,56 @@
+use strict;
+use Test::More;
+
+use Plack::Builder;
+use Plack::Test;
+use Scope::Container;
+
+sub container {
+    if ( my $container = scope_container('key') ) {
+        return $container;
+    }
+    else {
+        my $container = {};
+        scope_container('key',$container);
+        return $container;
+    }
+}
+
+my $app = builder {
+  enable 'Scope::Container';
+  sub {
+    my $env = shift;
+    sub { 
+        my $responder = shift;
+        my $writer = $responder->(["200",["Content-Type"=>"text/plain"]]);
+        my $val1 = container();
+        $writer->write('');
+        my $val2 = container();
+        $writer->write("$val1 $val2");
+        $writer->close;
+    }
+  }
+};
+
+
+test_psgi
+    app => $app,
+    client => sub {
+        my $cb = shift;
+        my $req = HTTP::Request->new(GET => "http://localhost/");
+        my $res = $cb->($req);
+        ok( $res->is_success );
+        my @content = split / /, $res->content;
+        ok( $content[0] );
+        is( $content[0], $content[1] );
+
+        my $req2 = HTTP::Request->new(GET => "http://localhost/");
+        my $res2 = $cb->($req2);
+        ok( $res2->is_success );
+        my @content2 = split / /, $res2->content;
+        ok( $content2[0] );
+        isnt( $content2[0], $content[0]);
+
+    };
+
+done_testing();


### PR DESCRIPTION
`$mw->response_cb($res, \&cb)`'s `&cb` is called when the response is first created and not the response  finished, especially when streaming. So when you start a streaming response and want to write it afterwards, the `Scope::Container` is destroyed when you get streaming $writer. (41ee626d01121e85625d421691b6dab3fe4607bb)

To solve this problem, I think keeping `Scope::Container` reference in `$env` would be good, whose reference is keeped until the streaming subroutine ends.
